### PR TITLE
Improving parser and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,33 +24,33 @@ describe "Docopt" do
 
   it "works" do
     doc = <<-DOC
-Naval Fate.
+    Naval Fate.
 
-Usage:
-  naval_fate ship new <name>...
-  naval_fate ship <name> move <x> <y> [--speed=<kn>]
-  naval_fate ship shoot <x> <y>
-  naval_fate mine (set|remove) <x> <y> [--moored|--drifting]
-  naval_fate -h | --help
-  naval_fate --version
+    Usage:
+      naval_fate ship new <name>...
+      naval_fate ship <name> move <x> <y> [--speed=<kn>]
+      naval_fate ship shoot <x> <y>
+      naval_fate mine (set|remove) <x> <y> [--moored|--drifting]
+      naval_fate -h | --help
+      naval_fate --version
 
-Options:
-  -h --help     Show this screen.
-  --version     Show version.
-  --speed=<kn>  Speed in knots [default: 10].
-  --moored      Moored (anchored) mine.
-  --drifting    Drifting mine.
-DOC
+    Options:
+      -h --help     Show this screen.
+      --version     Show version.
+      --speed=<kn>  Speed in knots [default: 10].
+      --moored      Moored (anchored) mine.
+      --drifting    Drifting mine.
+    DOC
     std = {"ship" => true, "new" => false, "<name>" => ["A"], "move" => true, "<x>" => "a", "<y>" => "b", "--speed" => "3", "shoot" => false, "mine" => false, "set" => false, "remove" => false, "--moored" => nil, "--drifting" => nil, "-h" => nil, "--help" => false, "--version" => nil}
     ans = Docopt.docopt(doc, argv = ["ship", "A", "move", "a", "b", "--speed=3"])
     ans["<name>"].should eq(std["<name>"])
   end
   it "one or more" do
     doc = <<-DOC
-test
-Usage:
-    naval [--files=files...]
-DOC
+    test
+    Usage:
+        naval [--files=files...]
+    DOC
     ans = Docopt.docopt(doc, argv = ["--files=a.txt", "--files=b.txt"])
     farr = ans["--files"] as Array(String)
     "a.txt".should eq(farr[0])
@@ -58,7 +58,6 @@ DOC
   end
 end
 ```
-
 
 TODO: Write usage instructions here
 

--- a/spec/docopt_spec.cr
+++ b/spec/docopt_spec.cr
@@ -3,38 +3,61 @@ require "./spec_helper"
 describe "Docopt" do
   # TODO: Write tests
 
-  it "works" do
-    doc = <<-DOC
-Naval Fate.
+  full_doc = <<-DOC
+  Naval Fate.
 
-Usage:
-  naval_fate ship new <name>...
-  naval_fate ship <name> move <x> <y> [--speed=<kn>]
-  naval_fate ship shoot <x> <y>
-  naval_fate mine (set|remove) <x> <y> [--moored|--drifting]
-  naval_fate -h | --help
-  naval_fate --version
+  Usage:
+    naval_fate init [-v]...
+    naval_fate ship new <name>...
+    naval_fate ship <name> move <x> <y> [--speed=<kn>]
+    naval_fate ship shoot <x> <y>
+    naval_fate mine (set|remove) <x> <y> [--moored|--drifting]
+    naval_fate save [--files=files...]
+    naval_fate set_speed [--speed=<kn>]
+    naval_fate -h | --help
+    naval_fate --version
 
-Options:
-  -h --help     Show this screen.
-  --version     Show version.
-  --speed=<kn>  Speed in knots [default: 10].
-  --moored      Moored (anchored) mine.
-  --drifting    Drifting mine.
-DOC
-    std = {"ship" => true, "new" => false, "<name>" => ["A"], "move" => true, "<x>" => "a", "<y>" => "b", "--speed" => "3", "shoot" => false, "mine" => false, "set" => false, "remove" => false, "--moored" => nil, "--drifting" => nil, "-h" => nil, "--help" => false, "--version" => nil}
-    ans = Docopt.docopt(doc, argv = ["ship", "A", "move", "a", "b", "--speed=3"])
-    ans["<name>"].should eq(std["<name>"])
+  Options:
+    -h --help        Show this screen.
+    --version        Show version.
+    -s,--speed=<kn>  Speed in knots [default: 10].
+    --moored         Moored (anchored) mine.
+    --drifting       Drifting mine.
+  DOC
+
+  # Test helper
+  process = ->(argv : Array(String)) {
+    Docopt.docopt(full_doc, argv, help: false, exit: false)
+  }
+
+  it "should match with subcommands and options" do
+    std = {"ship" => true, "new" => false, "<name>" => ["A"], "move" => true, "<x>" => "a", "<y>" => "b", "--speed" => "3", "shoot" => false, "mine" => false, "set" => false, "remove" => false, "--moored" => nil, "--drifting" => nil, "-h" => nil, "--help" => nil, "--version" => nil}
+    ans = process.call(["ship", "A", "move", "a", "b", "--speed=3"])
+    std.each do |key, value|
+      ans[key]?.should eq(value), "the key #{key} does not match the expected"
+    end
   end
-  it "one or more" do
-    doc = <<-DOC
-test
-Usage:
-    naval [--files=files...]
-DOC
-    ans = Docopt.docopt(doc, argv = ["--files=a.txt", "--files=b.txt"])
+
+  it "should support repeat options" do
+    # With value
+    ans = process.call(["save", "--files=a.txt", "--files=b.txt"])
     farr = ans["--files"] as Array(String)
     "a.txt".should eq(farr[0])
     "b.txt".should eq(farr[1])
+
+    # Only repeat
+    ans = process.call(["init", "-vv"])
+    ans["init"].should be_true
+    ans["-v"].should eq(2)
+  end
+
+  it("should support alias options with default value") do
+    ans = process.call(["set_speed"])
+    ans["set_speed"].should be_true
+    ans["--speed"].should eq("10")
+    ans = process.call(["set_speed", "--speed", "20"])
+    ans["--speed"].should eq("20")
+    ans = process.call(["-h"])
+    ans["--help"].should be_true
   end
 end

--- a/spec/docopt_spec.cr
+++ b/spec/docopt_spec.cr
@@ -60,4 +60,10 @@ describe "Docopt" do
     ans = process.call(["-h"])
     ans["--help"].should be_true
   end
+
+  it("should raise exception if not match") do
+    expect_raises(Exception) do
+      Docopt.docopt("", ["ship"], help: false, exit: false)
+    end
+  end
 end

--- a/src/docopt.cr
+++ b/src/docopt.cr
@@ -18,7 +18,7 @@ module Docopt
     property :error
     @error : (DocoptExit.class | DocoptLanguageError.class)
 
-    def initialize(@error = DocoptExit : (DocoptExit.class | DocoptLanguageError.class))
+    def initialize(@error : (DocoptExit.class | DocoptLanguageError.class) = DocoptExit)
       super()
     end
 
@@ -147,7 +147,7 @@ module Docopt
 
     abstract def flat(*types)
 
-    abstract def match(left : Array(Pattern), collected = nil : (Nil | Array(Pattern))) : Tuple(Bool, Array(Pattern), Array(Pattern))
+    abstract def match(left : Array(Pattern), collected : (Nil | Array(Pattern)) = nil) : Tuple(Bool, Array(Pattern), Array(Pattern))
     #  return false, left, ([] of Pattern)
     # end
   end
@@ -171,7 +171,7 @@ module Docopt
       return [] of Pattern
     end
 
-    def match(left : Array(Pattern), collected = nil : (Nil | Array(Pattern))) : Tuple(Bool, Array(Pattern), Array(Pattern))
+    def match(left : Array(Pattern), collected : (Nil | Array(Pattern)) = nil) : Tuple(Bool, Array(Pattern), Array(Pattern))
       # def match(left, collected = nil)
       # @TODO
       collected = [] of Pattern if collected.nil?
@@ -241,7 +241,7 @@ module Docopt
   end
 
   class Required < BranchPattern
-    def match(left : Array(Pattern), collected = nil : (Nil | Array(Pattern))) : Tuple(Bool, Array(Pattern), Array(Pattern))
+    def match(left : Array(Pattern), collected : (Nil | Array(Pattern)) = nil) : Tuple(Bool, Array(Pattern), Array(Pattern))
       # def match(left, collected = nil)
       collected = [] of Pattern if collected.nil?
       l = left
@@ -258,7 +258,7 @@ module Docopt
   end
 
   class Optional < BranchPattern
-    def match(left : Array(Pattern), collected = nil : (Nil | Array(Pattern))) : Tuple(Bool, Array(Pattern), Array(Pattern))
+    def match(left : Array(Pattern), collected : (Nil | Array(Pattern)) = nil) : Tuple(Bool, Array(Pattern), Array(Pattern))
       # def match(left, collected = nil)
       collected = [] of Pattern if collected.nil?
       ch = @children as Array(Pattern)
@@ -312,7 +312,7 @@ module Docopt
   end
 
   class OneOrMore < BranchPattern
-    def match(left : Array(Pattern), collected = nil : (Nil | Array(Pattern))) : Tuple(Bool, Array(Pattern), Array(Pattern))
+    def match(left : Array(Pattern), collected : (Nil | Array(Pattern)) = nil) : Tuple(Bool, Array(Pattern), Array(Pattern))
       # def match(left, collected = nil)
       ch = @children as Array(Pattern)
       raise "#{ch}.size != 1" if ch.size != 1
@@ -338,7 +338,7 @@ module Docopt
   end
 
   class Either < BranchPattern
-    def match(left : Array(Pattern), collected = nil : (Nil | Array(Pattern))) : Tuple(Bool, Array(Pattern), Array(Pattern))
+    def match(left : Array(Pattern), collected : (Nil | Array(Pattern)) = nil) : Tuple(Bool, Array(Pattern), Array(Pattern))
       # def match(left, collected = nil)
       collected = [] of Pattern if collected.nil?
       outcomes = [] of Tuple(Bool, Array(Pattern), Array(Pattern))


### PR DESCRIPTION
This PR includes changes from #1 and:
- Fixes the options parser to properly support alias options, separating the option name from the option description with two whitespaces;
- Adds the option `exit`, which helps during tests (avoiding premature exit when a test fails) and allowing a better control over the parser, just like in most of the docopt implementations;
- Removes a duplicated error handler (`DocoptExit` and a inheritance from `Exception`), so that it can be used to capture both type of error;
- Refactors new tests and adds new ones;
- Indentation HEREDOC strings. As per Crystal docs (see http://crystal-lang.org/docs/syntax_and_semantics/literals/string.html), HEREDOC trims off indentation chars, making the code cleaner.
