### PR TITLE
Correct typos in Exception class names.

### DIFF
--- a/src/docopt.cr
+++ b/src/docopt.cr
@@ -1,11 +1,11 @@
 module Docopt
-  class DocoptEception < Exception
+  class DocoptException < Exception
   end
 
-  class DocoptLanguageError < DocoptEception
+  class DocoptLanguageError < DocoptException
   end
 
-  class DocoptExit < DocoptEception
+  class DocoptExit < DocoptException
     @@usage = ""
 
     def self.usage=(u : String)

--- a/src/docopt/version.cr
+++ b/src/docopt/version.cr
@@ -1,3 +1,3 @@
 module Docopt
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Bump version to v0.2.0 since this technically breaks the API for anyone calling the Exception classes in their own code.